### PR TITLE
Lambdas encoder cleanup

### DIFF
--- a/aws_lambda/aws_lambda_stack.py
+++ b/aws_lambda/aws_lambda_stack.py
@@ -235,7 +235,7 @@ class AwsLambdaStack(core.Stack):
         users_remove = users.add_resource("remove").add_resource("{user_id}")
         users_remove.add_method("DELETE", users_remove_integration)
 
-        # FIND /users/find/{user_id}
+        # GET /users/find/{user_id}
         users_find = users.add_resource("find").add_resource("{user_id}")
         users_find.add_method("GET", users_find_integration)
 
@@ -266,7 +266,7 @@ class AwsLambdaStack(core.Stack):
         orders_item_add = orders.add_resource("addItem").add_resource("{order_id}").add_resource("{item_id}")
         orders_item_add.add_method("POST", orders_item_add_integration)
 
-        # POST /orders/removeItem/{order_id}/{item_id}
+        # DELETE /orders/removeItem/{order_id}/{item_id}
         orders_item_remove = orders.add_resource("removeItem").add_resource("{order_id}").add_resource("{item_id}")
         orders_item_remove.add_method("DELETE", orders_item_remove_integration)
 

--- a/services/orders_create/lambda_function.py
+++ b/services/orders_create/lambda_function.py
@@ -25,7 +25,7 @@ def lambda_handler(event, context):
                 'total_cost': decimal.Decimal('0.0')
             }
         )
-        res = str(json.dumps(response, default=str))
+        res = json.dumps(response, default=str)
         statusCode = 200
         body = json.dumps({
             'order_id': order_id

--- a/services/orders_create/lambda_function.py
+++ b/services/orders_create/lambda_function.py
@@ -3,23 +3,11 @@ import json
 import uuid
 import boto3
 import decimal
-from botocore.exceptions import ClientError
 
 # get the service resource
 dynamodb = boto3.resource('dynamodb')
 # get the users table
 ORDERS_TABLE = os.environ['ORDERS_TABLE']
-
-# helper class to convert a DynamoDB item to JSON
-# for details see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GettingStarted.Python.03.html
-class DecimalEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, decimal.Decimal):
-            if abs(o) % 1 > 0:
-                return float(o)
-            else:
-                return int(o)
-        return super(DecimalEncoder, self).default(o)
 
 def lambda_handler(event, context):
     
@@ -37,13 +25,13 @@ def lambda_handler(event, context):
                 'total_cost': decimal.Decimal('0.0')
             }
         )
-        res = str(json.dumps(response, cls=DecimalEncoder))
+        res = str(json.dumps(response, default=str))
         statusCode = 200
         body = json.dumps({
             'order_id': order_id
         })
         print(f'put_item result: {res}')
-    except ClientError as e:
+    except Exception as e:
         statusCode = 400
         body = json.dumps({})
         print(f'put_item error: {e}')

--- a/services/orders_find/lambda_function.py
+++ b/services/orders_find/lambda_function.py
@@ -3,24 +3,11 @@ import json
 import uuid
 import boto3
 import decimal
-from boto3.dynamodb.conditions import Key, Attr
-from botocore.exceptions import ClientError
 
 # get the service resource
 dynamodb = boto3.resource('dynamodb')
 # get the users table
 ORDERS_TABLE = os.environ['ORDERS_TABLE']
-
-# helper class to convert a DynamoDB item to JSON
-# for details see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GettingStarted.Python.03.html
-class DecimalEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, decimal.Decimal):
-            if abs(o) % 1 > 0:
-                return float(o)
-            else:
-                return int(o)
-        return super(DecimalEncoder, self).default(o)
 
 def lambda_handler(event, context):
     
@@ -29,7 +16,7 @@ def lambda_handler(event, context):
 
     try:
         response = orders_table.get_item(Key={'id': order_id})
-        res = str(json.dumps(response, cls=DecimalEncoder))
+        res = str(json.dumps(response, default=str))
         item = response['Item']
         print(f'get_item result: {res}')
         statusCode = 200
@@ -39,8 +26,8 @@ def lambda_handler(event, context):
             'items': item['items'],
             'user_id': item['user_id'],
             'total_cost': item['total_cost']
-        }, cls=DecimalEncoder)
-    except ClientError as e:
+        }, default=str)
+    except Exception as e:
         print(f'get_item error: {e}')
         statusCode = 400
         body = json.dumps({})

--- a/services/orders_find/lambda_function.py
+++ b/services/orders_find/lambda_function.py
@@ -16,7 +16,7 @@ def lambda_handler(event, context):
 
     try:
         response = orders_table.get_item(Key={'id': order_id})
-        res = str(json.dumps(response, default=str))
+        res = json.dumps(response, default=str)
         item = response['Item']
         print(f'get_item result: {res}')
         statusCode = 200

--- a/services/orders_item_add/lambda_function.py
+++ b/services/orders_item_add/lambda_function.py
@@ -3,25 +3,12 @@ import json
 import uuid
 import boto3
 import decimal
-from boto3.dynamodb.conditions import Key, Attr
-from botocore.exceptions import ClientError
 
 # get the service resource
 dynamodb = boto3.resource('dynamodb')
 # get the users table
 ORDERS_TABLE = os.environ['ORDERS_TABLE']
 STOCK_TABLE = os.environ['STOCK_TABLE']
-
-# helper class to convert a DynamoDB item to JSON
-# for details see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GettingStarted.Python.03.html
-class DecimalEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, decimal.Decimal):
-            if abs(o) % 1 > 0:
-                return float(o)
-            else:
-                return int(o)
-        return super(DecimalEncoder, self).default(o)
 
 def lambda_handler(event, context):
     
@@ -36,8 +23,8 @@ def lambda_handler(event, context):
         order_items = order_object['Item']['items']
         order_items.append(item_id)
 
-        print(f'get_item order result: {str(json.dumps(order_object, cls=DecimalEncoder))}')
-        print(f'get_item stock result: {str(json.dumps(stock_object, cls=DecimalEncoder))}')
+        print(f'get_item order result: {str(json.dumps(order_object, default=str))}')
+        print(f'get_item stock result: {str(json.dumps(stock_object, default=str))}')
 
         response = orders_table.update_item(
             Key={'id': order_id},
@@ -46,11 +33,11 @@ def lambda_handler(event, context):
             ExpressionAttributeNames={'#tms': 'items'},
             ReturnValues="UPDATED_NEW"
         )
-        res = str(json.dumps(response, cls=DecimalEncoder))
+        res = str(json.dumps(response, default=str))
         print(f'item successfully added to order: {res}')
 
         statusCode = 200
-    except ClientError as e:
+    except Exception as e:
         print(f'get_item error: {e}')
         statusCode = 400
 

--- a/services/orders_item_add/lambda_function.py
+++ b/services/orders_item_add/lambda_function.py
@@ -33,7 +33,7 @@ def lambda_handler(event, context):
             ExpressionAttributeNames={'#tms': 'items'},
             ReturnValues="UPDATED_NEW"
         )
-        res = str(json.dumps(response, default=str))
+        res = json.dumps(response, default=str)
         print(f'item successfully added to order: {res}')
 
         statusCode = 200

--- a/services/orders_item_remove/lambda_function.py
+++ b/services/orders_item_remove/lambda_function.py
@@ -33,7 +33,7 @@ def lambda_handler(event, context):
             ExpressionAttributeNames={'#tms': 'items'},
             ReturnValues="UPDATED_NEW"
         )
-        res = str(json.dumps(response, default=str))
+        res = json.dumps(response, default=str)
         print(f'item successfully added to order: {res}')
 
         statusCode = 200

--- a/services/orders_item_remove/lambda_function.py
+++ b/services/orders_item_remove/lambda_function.py
@@ -3,25 +3,12 @@ import json
 import uuid
 import boto3
 import decimal
-from boto3.dynamodb.conditions import Key, Attr
-from botocore.exceptions import ClientError
 
 # get the service resource
 dynamodb = boto3.resource('dynamodb')
 # get the users table
 ORDERS_TABLE = os.environ['ORDERS_TABLE']
 STOCK_TABLE = os.environ['STOCK_TABLE']
-
-# helper class to convert a DynamoDB item to JSON
-# for details see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GettingStarted.Python.03.html
-class DecimalEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, decimal.Decimal):
-            if abs(o) % 1 > 0:
-                return float(o)
-            else:
-                return int(o)
-        return super(DecimalEncoder, self).default(o)
 
 def lambda_handler(event, context):
     
@@ -36,8 +23,8 @@ def lambda_handler(event, context):
         order_items = order_object['Item']['items']
         order_items.remove(item_id)
 
-        print(f'get_item order result: {str(json.dumps(order_object, cls=DecimalEncoder))}')
-        print(f'get_item stock result: {str(json.dumps(stock_object, cls=DecimalEncoder))}')
+        print(f'get_item order result: {str(json.dumps(order_object, default=str))}')
+        print(f'get_item stock result: {str(json.dumps(stock_object, default=str))}')
 
         response = orders_table.update_item(
             Key={'id': order_id},
@@ -46,15 +33,15 @@ def lambda_handler(event, context):
             ExpressionAttributeNames={'#tms': 'items'},
             ReturnValues="UPDATED_NEW"
         )
-        res = str(json.dumps(response, cls=DecimalEncoder))
+        res = str(json.dumps(response, default=str))
         print(f'item successfully added to order: {res}')
 
         statusCode = 200
-    except ClientError as e:
-        print(f'get_item error: {e}')
-        statusCode = 400
     except ValueError as e:
         print(f'get_item error (item does not exist in list): {e}')
+        statusCode = 400
+    except Exception as e:
+        print(f'get_item error: {e}')
         statusCode = 400
 
     return {

--- a/services/orders_remove/lambda_function.py
+++ b/services/orders_remove/lambda_function.py
@@ -16,7 +16,7 @@ def lambda_handler(event, context):
 
     try:
         response = orders_table.delete_item(Key={'id': order_id})
-        res = str(json.dumps(response, default=str))
+        res = json.dumps(response, default=str)
         print(f'order successfully removed: {res}')
         statusCode = 200
     except Exception as e:

--- a/services/orders_remove/lambda_function.py
+++ b/services/orders_remove/lambda_function.py
@@ -3,23 +3,11 @@ import json
 import uuid
 import boto3
 import decimal
-from botocore.exceptions import ClientError
 
 # get the service resource
 dynamodb = boto3.resource('dynamodb')
 # get the users table
 ORDERS_TABLE = os.environ['ORDERS_TABLE']
-
-# helper class to convert a DynamoDB item to JSON
-# for details see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GettingStarted.Python.03.html
-class DecimalEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, decimal.Decimal):
-            if abs(o) % 1 > 0:
-                return float(o)
-            else:
-                return int(o)
-        return super(DecimalEncoder, self).default(o)
 
 def lambda_handler(event, context):
 
@@ -28,10 +16,10 @@ def lambda_handler(event, context):
 
     try:
         response = orders_table.delete_item(Key={'id': order_id})
-        res = str(json.dumps(response, cls=DecimalEncoder))
+        res = str(json.dumps(response, default=str))
         print(f'order successfully removed: {res}')
         statusCode = 200
-    except ClientError as e:
+    except Exception as e:
         print(f'delete_item error: {e}')
         statusCode = 400
 

--- a/services/stock_add/lambda_function.py
+++ b/services/stock_add/lambda_function.py
@@ -26,7 +26,7 @@ def lambda_handler(event, context):
             ExpressionAttributeValues={':stock': decimal.Decimal(new_stock)},
             ReturnValues="UPDATED_NEW"
         )
-        res = str(json.dumps(response, default=str))
+        res = json.dumps(response, default=str)
         print(f'stock successfully added: {res}')
         statusCode = 200
     except Exception as e:

--- a/services/stock_add/lambda_function.py
+++ b/services/stock_add/lambda_function.py
@@ -3,24 +3,11 @@ import json
 import uuid
 import boto3
 import decimal
-from boto3.dynamodb.conditions import Key, Attr
-from botocore.exceptions import ClientError
 
 # get the service resource
 dynamodb = boto3.resource('dynamodb')
 # get the users table
 STOCK_TABLE = os.environ['STOCK_TABLE']
-
-# helper class to convert a DynamoDB item to JSON
-# for details see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GettingStarted.Python.03.html
-class DecimalEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, decimal.Decimal):
-            if abs(o) % 1 > 0:
-                return float(o)
-            else:
-                return int(o)
-        return super(DecimalEncoder, self).default(o)
 
 def lambda_handler(event, context):
     
@@ -39,10 +26,10 @@ def lambda_handler(event, context):
             ExpressionAttributeValues={':stock': decimal.Decimal(new_stock)},
             ReturnValues="UPDATED_NEW"
         )
-        res = str(json.dumps(response, cls=DecimalEncoder))
+        res = str(json.dumps(response, default=str))
         print(f'stock successfully added: {res}')
         statusCode = 200
-    except ClientError as e:
+    except Exception as e:
         print(f'update_item error: {e}')
         statusCode = 400
 

--- a/services/stock_create/lambda_function.py
+++ b/services/stock_create/lambda_function.py
@@ -23,7 +23,7 @@ def lambda_handler(event, context):
                 'price': decimal.Decimal(price)
             }
         )
-        res = str(json.dumps(response, default=str))
+        res = json.dumps(response, default=str)
         statusCode = 200
         body = json.dumps({
             'item_id': item_id

--- a/services/stock_create/lambda_function.py
+++ b/services/stock_create/lambda_function.py
@@ -3,23 +3,11 @@ import json
 import uuid
 import boto3
 import decimal
-from botocore.exceptions import ClientError
 
 # get the service resource
 dynamodb = boto3.resource('dynamodb')
 # get the users table
 STOCK_TABLE = os.environ['STOCK_TABLE']
-
-# helper class to convert a DynamoDB item to JSON
-# for details see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GettingStarted.Python.03.html
-class DecimalEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, decimal.Decimal):
-            if abs(o) % 1 > 0:
-                return float(o)
-            else:
-                return int(o)
-        return super(DecimalEncoder, self).default(o)
 
 def lambda_handler(event, context):
     
@@ -35,13 +23,13 @@ def lambda_handler(event, context):
                 'price': decimal.Decimal(price)
             }
         )
-        res = str(json.dumps(response, cls=DecimalEncoder))
+        res = str(json.dumps(response, default=str))
         statusCode = 200
         body = json.dumps({
             'item_id': item_id
         })
         print(f'put_item result: {res}')
-    except ClientError as e:
+    except Exception as e:
         statusCode = 400
         body = json.dumps({})
         print(f'put_item error: {e}')

--- a/services/stock_find/lambda_function.py
+++ b/services/stock_find/lambda_function.py
@@ -16,7 +16,7 @@ def lambda_handler(event, context):
 
     try:
         response = stock_table.get_item(Key={'id': item_id})
-        res = str(json.dumps(response, default=str))
+        res = json.dumps(response, default=str)
         item = response['Item']
         print(f'get_item result: {res}')
         statusCode = 200

--- a/services/stock_find/lambda_function.py
+++ b/services/stock_find/lambda_function.py
@@ -3,24 +3,11 @@ import json
 import uuid
 import boto3
 import decimal
-from boto3.dynamodb.conditions import Key, Attr
-from botocore.exceptions import ClientError
 
 # get the service resource
 dynamodb = boto3.resource('dynamodb')
 # get the users table
 STOCK_TABLE = os.environ['STOCK_TABLE']
-
-# helper class to convert a DynamoDB item to JSON
-# for details see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GettingStarted.Python.03.html
-class DecimalEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, decimal.Decimal):
-            if abs(o) % 1 > 0:
-                return float(o)
-            else:
-                return int(o)
-        return super(DecimalEncoder, self).default(o)
 
 def lambda_handler(event, context):
     
@@ -29,7 +16,7 @@ def lambda_handler(event, context):
 
     try:
         response = stock_table.get_item(Key={'id': item_id})
-        res = str(json.dumps(response, cls=DecimalEncoder))
+        res = str(json.dumps(response, default=str))
         item = response['Item']
         print(f'get_item result: {res}')
         statusCode = 200
@@ -37,8 +24,8 @@ def lambda_handler(event, context):
             'item_id': item['id'],
             'stock': item['stock'],
             'price': item['price']
-        }, cls=DecimalEncoder)
-    except ClientError as e:
+        }, default=str)
+    except Exception as e:
         print(f'get_item error: {e}')
         statusCode = 400
         body = json.dumps({})

--- a/services/stock_subtract/lambda_function.py
+++ b/services/stock_subtract/lambda_function.py
@@ -3,24 +3,11 @@ import json
 import uuid
 import boto3
 import decimal
-from boto3.dynamodb.conditions import Key, Attr
-from botocore.exceptions import ClientError
 
 # get the service resource
 dynamodb = boto3.resource('dynamodb')
 # get the users table
 STOCK_TABLE = os.environ['STOCK_TABLE']
-
-# helper class to convert a DynamoDB item to JSON
-# for details see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GettingStarted.Python.03.html
-class DecimalEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, decimal.Decimal):
-            if abs(o) % 1 > 0:
-                return float(o)
-            else:
-                return int(o)
-        return super(DecimalEncoder, self).default(o)
 
 def lambda_handler(event, context):
     
@@ -39,10 +26,10 @@ def lambda_handler(event, context):
             ExpressionAttributeValues={':stock': decimal.Decimal(new_stock)},
             ReturnValues="UPDATED_NEW"
         )
-        res = str(json.dumps(response, cls=DecimalEncoder))
+        res = str(json.dumps(response, default=str))
         print(f'stock successfully subtracted: {res}')
         statusCode = 200
-    except ClientError as e:
+    except Exception as e:
         print(f'update_item error: {e}')
         statusCode = 400
 

--- a/services/stock_subtract/lambda_function.py
+++ b/services/stock_subtract/lambda_function.py
@@ -26,7 +26,7 @@ def lambda_handler(event, context):
             ExpressionAttributeValues={':stock': decimal.Decimal(new_stock)},
             ReturnValues="UPDATED_NEW"
         )
-        res = str(json.dumps(response, default=str))
+        res = json.dumps(response, default=str)
         print(f'stock successfully subtracted: {res}')
         statusCode = 200
     except Exception as e:

--- a/services/users_create/lambda_function.py
+++ b/services/users_create/lambda_function.py
@@ -16,7 +16,7 @@ def lambda_handler(event, context):
 
     try:
         response = users_table.put_item(Item = {'id': user_id, 'credit': decimal.Decimal('0.0')})
-        res = str(json.dumps(response, default=str))
+        res = json.dumps(response, default=str)
         statusCode = 200
         body = json.dumps({
             'user_id': user_id

--- a/services/users_create/lambda_function.py
+++ b/services/users_create/lambda_function.py
@@ -3,23 +3,11 @@ import json
 import uuid
 import boto3
 import decimal
-from botocore.exceptions import ClientError
 
 # get the service resource
 dynamodb = boto3.resource('dynamodb')
 # get the users table
 USERS_TABLE = os.environ['USERS_TABLE']
-
-# helper class to convert a DynamoDB item to JSON
-# for details see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GettingStarted.Python.03.html
-class DecimalEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, decimal.Decimal):
-            if abs(o) % 1 > 0:
-                return float(o)
-            else:
-                return int(o)
-        return super(DecimalEncoder, self).default(o)
 
 def lambda_handler(event, context):
     
@@ -28,13 +16,13 @@ def lambda_handler(event, context):
 
     try:
         response = users_table.put_item(Item = {'id': user_id, 'credit': decimal.Decimal('0.0')})
-        res = str(json.dumps(response, cls=DecimalEncoder))
+        res = str(json.dumps(response, default=str))
         statusCode = 200
         body = json.dumps({
             'user_id': user_id
         })
         print(f'put_item result: {res}')
-    except ClientError as e:
+    except Exception as e:
         statusCode = 400
         body = json.dumps({})
         print(f'put_item error: {e}')

--- a/services/users_credit_add/lambda_function.py
+++ b/services/users_credit_add/lambda_function.py
@@ -3,24 +3,11 @@ import json
 import uuid
 import boto3
 import decimal
-from boto3.dynamodb.conditions import Key, Attr
-from botocore.exceptions import ClientError
 
 # get the service resource
 dynamodb = boto3.resource('dynamodb')
 # get the users table
 USERS_TABLE = os.environ['USERS_TABLE']
-
-# helper class to convert a DynamoDB item to JSON
-# for details see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GettingStarted.Python.03.html
-class DecimalEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, decimal.Decimal):
-            if abs(o) % 1 > 0:
-                return float(o)
-            else:
-                return int(o)
-        return super(DecimalEncoder, self).default(o)
 
 def lambda_handler(event, context):
     
@@ -39,10 +26,10 @@ def lambda_handler(event, context):
             ExpressionAttributeValues={':credit': decimal.Decimal(new_credit)},
             ReturnValues="UPDATED_NEW"
         )
-        res = str(json.dumps(response, cls=DecimalEncoder))
+        res = str(json.dumps(response, default=str))
         print(f'credit successfully added: {res}')
         statusCode = 200
-    except ClientError as e:
+    except Exception as e:
         print(f'update_item error: {e}')
         statusCode = 400
 

--- a/services/users_credit_add/lambda_function.py
+++ b/services/users_credit_add/lambda_function.py
@@ -26,7 +26,7 @@ def lambda_handler(event, context):
             ExpressionAttributeValues={':credit': decimal.Decimal(new_credit)},
             ReturnValues="UPDATED_NEW"
         )
-        res = str(json.dumps(response, default=str))
+        res = json.dumps(response, default=str)
         print(f'credit successfully added: {res}')
         statusCode = 200
     except Exception as e:

--- a/services/users_credit_subtract/lambda_function.py
+++ b/services/users_credit_subtract/lambda_function.py
@@ -26,7 +26,7 @@ def lambda_handler(event, context):
             ExpressionAttributeValues={':credit': decimal.Decimal(new_credit)},
             ReturnValues="UPDATED_NEW"
         )
-        res = str(json.dumps(response, default=str))
+        res = json.dumps(response, default=str)
         print(f'credit successfully subtracted: {res}')
         statusCode = 200
     except Exception as e:

--- a/services/users_credit_subtract/lambda_function.py
+++ b/services/users_credit_subtract/lambda_function.py
@@ -3,24 +3,11 @@ import json
 import uuid
 import boto3
 import decimal
-from boto3.dynamodb.conditions import Key, Attr
-from botocore.exceptions import ClientError
 
 # get the service resource
 dynamodb = boto3.resource('dynamodb')
 # get the users table
 USERS_TABLE = os.environ['USERS_TABLE']
-
-# helper class to convert a DynamoDB item to JSON
-# for details see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GettingStarted.Python.03.html
-class DecimalEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, decimal.Decimal):
-            if abs(o) % 1 > 0:
-                return float(o)
-            else:
-                return int(o)
-        return super(DecimalEncoder, self).default(o)
 
 def lambda_handler(event, context):
 
@@ -39,10 +26,10 @@ def lambda_handler(event, context):
             ExpressionAttributeValues={':credit': decimal.Decimal(new_credit)},
             ReturnValues="UPDATED_NEW"
         )
-        res = str(json.dumps(response, cls=DecimalEncoder))
+        res = str(json.dumps(response, default=str))
         print(f'credit successfully subtracted: {res}')
         statusCode = 200
-    except ClientError as e:
+    except Exception as e:
         print(f'update_item error: {e}')
         statusCode = 400
 

--- a/services/users_find/lambda_function.py
+++ b/services/users_find/lambda_function.py
@@ -3,24 +3,11 @@ import json
 import uuid
 import boto3
 import decimal
-from boto3.dynamodb.conditions import Key, Attr
-from botocore.exceptions import ClientError
 
 # get the service resource
 dynamodb = boto3.resource('dynamodb')
 # get the users table
 USERS_TABLE = os.environ['USERS_TABLE']
-
-# helper class to convert a DynamoDB item to JSON
-# for details see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GettingStarted.Python.03.html
-class DecimalEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, decimal.Decimal):
-            if abs(o) % 1 > 0:
-                return float(o)
-            else:
-                return int(o)
-        return super(DecimalEncoder, self).default(o)
 
 def lambda_handler(event, context):
     
@@ -29,15 +16,15 @@ def lambda_handler(event, context):
 
     try:
         response = users_table.get_item(Key={'id': user_id})
-        res = str(json.dumps(response, cls=DecimalEncoder))
+        res = str(json.dumps(response, default=str))
         item = response['Item']
         print(f'get_item result: {res}')
         statusCode = 200
         body = json.dumps({
             'user_id': item['id'],
             'credit': item['credit']
-        }, cls=DecimalEncoder)
-    except ClientError as e:
+        }, default=str)
+    except Exception as e:
         print(f'get_item error: {e}')
         statusCode = 400
         body = json.dumps({})

--- a/services/users_find/lambda_function.py
+++ b/services/users_find/lambda_function.py
@@ -16,7 +16,7 @@ def lambda_handler(event, context):
 
     try:
         response = users_table.get_item(Key={'id': user_id})
-        res = str(json.dumps(response, default=str))
+        res = json.dumps(response, default=str)
         item = response['Item']
         print(f'get_item result: {res}')
         statusCode = 200

--- a/services/users_remove/lambda_function.py
+++ b/services/users_remove/lambda_function.py
@@ -3,23 +3,11 @@ import json
 import uuid
 import boto3
 import decimal
-from botocore.exceptions import ClientError
 
 # get the service resource
 dynamodb = boto3.resource('dynamodb')
 # get the users table
 USERS_TABLE = os.environ['USERS_TABLE']
-
-# helper class to convert a DynamoDB item to JSON
-# for details see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GettingStarted.Python.03.html
-class DecimalEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, decimal.Decimal):
-            if abs(o) % 1 > 0:
-                return float(o)
-            else:
-                return int(o)
-        return super(DecimalEncoder, self).default(o)
 
 def lambda_handler(event, context):
 
@@ -28,10 +16,10 @@ def lambda_handler(event, context):
 
     try:
         response = users_table.delete_item(Key={'id': user_id})
-        res = str(json.dumps(response, cls=DecimalEncoder))
+        res = str(json.dumps(response, default=str))
         print(f'user successfully removed: {res}')
         statusCode = 200
-    except ClientError as e:
+    except Exception as e:
         print(f'delete_item error: {e}')
         statusCode = 400
 

--- a/services/users_remove/lambda_function.py
+++ b/services/users_remove/lambda_function.py
@@ -16,7 +16,7 @@ def lambda_handler(event, context):
 
     try:
         response = users_table.delete_item(Key={'id': user_id})
-        res = str(json.dumps(response, default=str))
+        res = json.dumps(response, default=str)
         print(f'user successfully removed: {res}')
         statusCode = 200
     except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setuptools.setup(
         "boto3",
         "botocore",
         "poetry",
-        "docker"
+        "docker",
+        "pylint"
     ],
 
     python_requires=">=3.6",


### PR DESCRIPTION
**DESCRIPTION:**
The decimal encoders were removed from the lambda functions. Turns out there is a simpler way for decoding the DynamoDB items when printing out results, that is converting to str by default. Also added pylint to the project dependecies list.

**ISSUES:**
closes #5 
closes #18 

**AUTHORS:**
@cldme 