### PR TITLE
Orders checkout

### DIFF
--- a/aws_lambda/orders_service.py
+++ b/aws_lambda/orders_service.py
@@ -30,6 +30,8 @@ class OrdersService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/orders/create"),
+            memory_size=256,
+            timeout=core.Duration.seconds(10),
             function_name="orders_create_lambda"
         )
         create_lambda.add_environment("ORDERS_TABLE", self.table.table_name)
@@ -41,6 +43,8 @@ class OrdersService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/orders/remove"),
+            memory_size=256,
+            timeout=core.Duration.seconds(10),
             function_name="orders_remove_lambda"
         )
         remove_lambda.add_environment("ORDERS_TABLE", self.table.table_name)
@@ -52,6 +56,8 @@ class OrdersService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/orders/find"),
+            memory_size=256,
+            timeout=core.Duration.seconds(10),
             function_name="orders_find_lambda"
         )
         find_lambda.add_environment("ORDERS_TABLE", self.table.table_name)
@@ -63,6 +69,8 @@ class OrdersService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/orders/item_add"),
+            memory_size=256,
+            timeout=core.Duration.seconds(10),
             function_name="orders_item_add_lambda"
         )
         item_add_lambda.add_environment("ORDERS_TABLE", self.table.table_name)
@@ -76,6 +84,8 @@ class OrdersService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/orders/item_remove"),
+            memory_size=256,
+            timeout=core.Duration.seconds(10),
             function_name="orders_item_remove_lambda"
         )
         item_remove_lambda.add_environment("ORDERS_TABLE", self.table.table_name)
@@ -89,6 +99,8 @@ class OrdersService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/orders/checkout"),
+            memory_size=256,
+            timeout=core.Duration.seconds(60),
             function_name="orders_checkout_lambda"
         )
         self.checkout_lambda.add_environment("ORDERS_TABLE", self.table.table_name)

--- a/aws_lambda/payment_service.py
+++ b/aws_lambda/payment_service.py
@@ -34,6 +34,7 @@ class PaymentService(core.Construct):
         pay_lambda.add_environment("USERS_TABLE", users.table.table_name)
         orders.table.grant_read_write_data(pay_lambda)
         users.table.grant_read_write_data(pay_lambda)
+        pay_lambda.grant_invoke(orders.checkout_lambda)
 
         cancel_lambda = aws_lambda.Function(
             self,
@@ -47,6 +48,7 @@ class PaymentService(core.Construct):
         cancel_lambda.add_environment("USERS_TABLE", users.table.table_name)
         orders.table.grant_read_write_data(cancel_lambda)
         users.table.grant_read_write_data(cancel_lambda)
+        cancel_lambda.grant_invoke(orders.checkout_lambda)
 
         # API Gateway integration
         status_integration = aws_apigateway.LambdaIntegration(status_lambda)

--- a/aws_lambda/payment_service.py
+++ b/aws_lambda/payment_service.py
@@ -17,6 +17,8 @@ class PaymentService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/payment/status"),
+            memory_size=256,
+            timeout=core.Duration.seconds(10),
             function_name="payment_status_lambda"
         )
         status_lambda.add_environment("ORDERS_TABLE", orders.table.table_name)
@@ -28,6 +30,8 @@ class PaymentService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/payment/pay"),
+            memory_size=256,
+            timeout=core.Duration.seconds(60),
             function_name="payment_pay_lambda"
         )
         pay_lambda.add_environment("ORDERS_TABLE", orders.table.table_name)
@@ -42,6 +46,8 @@ class PaymentService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/payment/cancel"),
+            memory_size=256,
+            timeout=core.Duration.seconds(60),
             function_name="payment_cancel_lambda"
         )
         cancel_lambda.add_environment("ORDERS_TABLE", orders.table.table_name)

--- a/aws_lambda/stock_service.py
+++ b/aws_lambda/stock_service.py
@@ -44,7 +44,7 @@ class StockService(core.Construct):
         find_lambda.add_environment("STOCK_TABLE", self.table.table_name)
         self.table.grant_read_write_data(find_lambda)
 
-        add_lambda = aws_lambda.Function(
+        self.add_lambda = aws_lambda.Function(
             self,
             "stock_add_lambda",
             runtime=aws_lambda.Runtime.PYTHON_3_6,
@@ -52,10 +52,10 @@ class StockService(core.Construct):
             code=aws_lambda.Code.asset("./services/stock/add"),
             function_name="stock_add_lambda"
         )
-        add_lambda.add_environment("STOCK_TABLE", self.table.table_name)
-        self.table.grant_read_write_data(add_lambda)
+        self.add_lambda.add_environment("STOCK_TABLE", self.table.table_name)
+        self.table.grant_read_write_data(self.add_lambda)
 
-        subtract_lambda = aws_lambda.Function(
+        self.subtract_lambda = aws_lambda.Function(
             self,
             "stock_subtract_lambda",
             runtime=aws_lambda.Runtime.PYTHON_3_6,
@@ -63,14 +63,14 @@ class StockService(core.Construct):
             code=aws_lambda.Code.asset("./services/stock/subtract"),
             function_name="stock_subtract_lambda"
         )
-        subtract_lambda.add_environment("STOCK_TABLE", self.table.table_name)
-        self.table.grant_read_write_data(subtract_lambda)
+        self.subtract_lambda.add_environment("STOCK_TABLE", self.table.table_name)
+        self.table.grant_read_write_data(self.subtract_lambda)
 
         # API Gateway integration
         create_integration = aws_apigateway.LambdaIntegration(create_lambda)
         find_integration = aws_apigateway.LambdaIntegration(find_lambda)
-        add_integration = aws_apigateway.LambdaIntegration(add_lambda)
-        subtract_integration = aws_apigateway.LambdaIntegration(subtract_lambda)
+        add_integration = aws_apigateway.LambdaIntegration(self.add_lambda)
+        subtract_integration = aws_apigateway.LambdaIntegration(self.subtract_lambda)
 
         # API Gateway
         # POST /stock/item/create/{price}

--- a/aws_lambda/stock_service.py
+++ b/aws_lambda/stock_service.py
@@ -28,6 +28,8 @@ class StockService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/stock/create"),
+            memory_size=256,
+            timeout=core.Duration.seconds(10),
             function_name="stock_create_lambda"
         )
         create_lambda.add_environment("STOCK_TABLE", self.table.table_name)
@@ -39,6 +41,8 @@ class StockService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/stock/find"),
+            memory_size=256,
+            timeout=core.Duration.seconds(10),
             function_name="stock_find_lambda"
         )
         find_lambda.add_environment("STOCK_TABLE", self.table.table_name)
@@ -50,6 +54,8 @@ class StockService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/stock/add"),
+            memory_size=256,
+            timeout=core.Duration.seconds(10),
             function_name="stock_add_lambda"
         )
         self.add_lambda.add_environment("STOCK_TABLE", self.table.table_name)
@@ -61,6 +67,8 @@ class StockService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/stock/subtract"),
+            memory_size=256,
+            timeout=core.Duration.seconds(10),
             function_name="stock_subtract_lambda"
         )
         self.subtract_lambda.add_environment("STOCK_TABLE", self.table.table_name)

--- a/aws_lambda/users_service.py
+++ b/aws_lambda/users_service.py
@@ -28,6 +28,8 @@ class UsersService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/users/create"),
+            memory_size=256,
+            timeout=core.Duration.seconds(10),
             function_name="users_create_lambda"
         )
         create_lambda.add_environment("USERS_TABLE", self.table.table_name)
@@ -39,6 +41,8 @@ class UsersService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/users/find"),
+            memory_size=256,
+            timeout=core.Duration.seconds(10),
             function_name="users_find_lambda"
         )
         find_lambda.add_environment("USERS_TABLE", self.table.table_name)
@@ -50,6 +54,8 @@ class UsersService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/users/remove"),
+            memory_size=256,
+            timeout=core.Duration.seconds(10),
             function_name="users_remove_lambda"
         )
         remove_lambda.add_environment("USERS_TABLE", self.table.table_name)
@@ -61,6 +67,8 @@ class UsersService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/users/credit_subtract"),
+            memory_size=256,
+            timeout=core.Duration.seconds(10),
             function_name="users_credit_subtract_lambda"
         )
         credit_subtract_lambda.add_environment("USERS_TABLE", self.table.table_name)
@@ -72,6 +80,8 @@ class UsersService(core.Construct):
             runtime=aws_lambda.Runtime.PYTHON_3_6,
             handler="lambda_function.lambda_handler",
             code=aws_lambda.Code.asset("./services/users/credit_add"),
+            memory_size=256,
+            timeout=core.Duration.seconds(10),
             function_name="users_credit_add_lambda"
         )
         credit_add_lambda.add_environment("USERS_TABLE", self.table.table_name)

--- a/services/orders/checkout/lambda_function.py
+++ b/services/orders/checkout/lambda_function.py
@@ -1,0 +1,88 @@
+import os
+import json
+import boto3
+import decimal
+
+# get the service resource
+dynamodb = boto3.resource('dynamodb')
+# get the users table
+ORDERS_TABLE = os.environ['ORDERS_TABLE']
+
+# invoke lambda function with given name and payload
+def invoke_lambda(name, payload, invocation_type='RequestResponse'):
+    print(f'invoking lambda function: {name}')
+    client = boto3.client('lambda')
+    payload = json.dumps(payload)
+    
+    res = client.invoke(
+        FunctionName=name,
+        InvocationType=invocation_type,
+        LogType='Tail',
+        Payload=bytes(payload, encoding='utf8')
+    )
+
+    return res
+
+def lambda_handler(event, context):
+    
+    orders_table = dynamodb.Table(ORDERS_TABLE)
+    order_id = event['pathParameters']['order_id']
+
+    try:
+        res = orders_table.get_item(Key={'id': order_id})
+        order = res['Item']
+
+        # make the payment via calling the payment service
+        print(f'making payment via calling the payment service')
+        payload = {
+            'pathParameters': {
+                'order_id': order_id,
+                'amount': str(order['total_cost'])
+            }
+        }
+        res = invoke_lambda('payment_pay_lambda', payload)
+
+        if res['StatusCode'] != 200:
+            raise ValueError('error thrown while making the payment | status: ' + res['StatusCode'])
+
+        print(f'done making the payment with result: {res}')
+
+        # subtract the stock via calling the stock service
+        print(f'subtract stock via calling the stock service')
+        items = order['items']
+        # keep track of the items that were updated (used for rollback in case of failure)
+        queue = list()
+        for item in items:
+            payload = {
+                'pathParameters': {
+                    'item_id': item,
+                    'number': '1'
+                }
+            }
+            res = invoke_lambda('stock_subtract_lambda', payload)
+
+            # in case of failure rollback previous actions
+            if res['StatusCode'] != 200:
+                print(f'failed updating stock with result: {res}')
+                print(f'rolling back now!')
+                # TODO: rollback user's payment
+                for q in queue:
+                    # invoke async lambda (no need to wait for results here)
+                    res = invoke_lambda('stock_add_lambda', q, 'Event')
+                # exit after rollback is complete
+                raise ValueError('error while updating the stock! rollback complete!')
+            
+            print(f'subtracted stock for item: {item} with result: {res}')
+            # in case of success add item to done queue
+            queue.append(payload)
+
+        print(f'done updating all stock!')
+
+        statusCode = 200
+    except Exception as e:
+        statusCode = 400
+        print(f'checkout error: {e}')
+
+    return {
+        "statusCode": statusCode
+    }

--- a/services/orders/checkout/lambda_function.py
+++ b/services/orders/checkout/lambda_function.py
@@ -23,6 +23,66 @@ def invoke_lambda(name, payload, invocation_type='RequestResponse'):
 
     return res
 
+# make payment
+def make_payment(order):
+    print(f'making payment via calling the payment service')
+    payload = {
+        'pathParameters': {
+            'user_id': order['user_id'],
+            'order_id': order['id'],
+            'amount': str(order['total_cost'])
+        }
+    }
+    res = invoke_lambda('payment_pay_lambda', payload)
+    # get result object from lambda call
+    res = json.loads(res['Payload'].read())
+    print(f'payment service result: {res}')
+
+    if res['statusCode'] != 200:
+        raise ValueError('error thrown while making the payment')
+
+# subtract stock
+def subtract_stock(order):
+    print(f'subtract stock via calling the stock service')
+    items = order['items']
+    # keep track of the items that were updated (used for rollback in case of failure)
+    queue = list()
+    for item in items:
+        payload = {
+            'pathParameters': {
+                'item_id': item,
+                'number': '1'
+            }
+        }
+        res = invoke_lambda('stock_subtract_lambda', payload)
+        # get result object from lambda call
+        res = json.loads(res['Payload'].read())
+        print(f'stock subtract service result: {res}')
+
+        # in case of failure rollback previous actions
+        if res['statusCode'] != 200:
+            print(f'failed updating stock with result: {res}')
+            print(f'rolling back now!')
+            # rollback user's payment
+            payload = {
+                'pathParameters': {
+                    'user_id': order['user_id'],
+                    'order_id': order['id']
+                }
+            }
+            # invoke async lambda (no need to wait for results here)
+            res = invoke_lambda('payment_cancel_lambda', payload, 'Event')
+            # rollback stock subtractions
+            for q in queue:
+                # invoke async lambda (no need to wait for results here)
+                res = invoke_lambda('stock_add_lambda', q, 'Event')
+            # exit after rollback is complete
+            raise ValueError('error while updating the stock! rollback complete!')
+        
+        print(f'subtracted stock for item: {item} with result: {res}')
+        # in case of success add item to done queue
+        queue.append(payload)
+
 def lambda_handler(event, context):
     
     orders_table = dynamodb.Table(ORDERS_TABLE)
@@ -33,64 +93,12 @@ def lambda_handler(event, context):
         order = res['Item']
 
         # make the payment via calling the payment service
-        print(f'making payment via calling the payment service')
-        payload = {
-            'pathParameters': {
-                'user_id': order['user_id'],
-                'order_id': order_id,
-                'amount': str(order['total_cost'])
-            }
-        }
-        res = invoke_lambda('payment_pay_lambda', payload)
-        # get result object from lambda call
-        res = json.loads(res['Payload'].read())
-        print(f'payment service result: {res}')
+        make_payment(order)
 
-        if res['statusCode'] != 200:
-            raise ValueError('error thrown while making the payment')
-
-        print(f'done making the payment with result: {res}')
+        print(f'done making the payment!')
 
         # subtract the stock via calling the stock service
-        print(f'subtract stock via calling the stock service')
-        items = order['items']
-        # keep track of the items that were updated (used for rollback in case of failure)
-        queue = list()
-        for item in items:
-            payload = {
-                'pathParameters': {
-                    'item_id': item,
-                    'number': '1'
-                }
-            }
-            res = invoke_lambda('stock_subtract_lambda', payload)
-            # get result object from lambda call
-            res = json.loads(res['Payload'].read())
-            print(f'stock subtract service result: {res}')
-
-            # in case of failure rollback previous actions
-            if res['statusCode'] != 200:
-                print(f'failed updating stock with result: {res}')
-                print(f'rolling back now!')
-                # rollback user's payment
-                payload = {
-                    'pathParameters': {
-                        'user_id': order['user_id'],
-                        'order_id': order_id
-                    }
-                }
-                # invoke async lambda (no need to wait for results here)
-                res = invoke_lambda('payment_cancel_lambda', payload, 'Event')
-                # rollback stock subtractions
-                for q in queue:
-                    # invoke async lambda (no need to wait for results here)
-                    res = invoke_lambda('stock_add_lambda', q, 'Event')
-                # exit after rollback is complete
-                raise ValueError('error while updating the stock! rollback complete!')
-            
-            print(f'subtracted stock for item: {item} with result: {res}')
-            # in case of success add item to done queue
-            queue.append(payload)
+        subtract_stock(order)
 
         print(f'done updating all stock!')
 

--- a/services/payment/status/lambda_function.py
+++ b/services/payment/status/lambda_function.py
@@ -2,7 +2,6 @@ import json
 import os
 
 import boto3
-from botocore.exceptions import ClientError
 
 dynamodb = boto3.resource('dynamodb')
 ORDERS_TABLE = os.environ['ORDERS_TABLE']
@@ -19,7 +18,7 @@ def lambda_handler(event, context):
         body = json.dumps({
             'paid': item['paid'],
         })
-    except ClientError as e:
+    except Exception as e:
         print(f'status error: {e}')
         statusCode = 400
         body = json.dumps({})


### PR DESCRIPTION
**DESCRIPTION:**
This PR adds the functionality for the /orders/checkout route. When calling this endpoint, a couple of things will happen. The payment service will be called for making the payment (via the /payment/pay route) then the stock for all items in the order will be updated. If at any point there is an error (i.e: either the user does not have enough credit or the stock is not available) the logic within the /orders/checkout will rollback any outstanding changes and bring the system back in a stable state (using SAGA model). Finally, all code was tested with the provided locust.io client with 100 users and hatch rate of 5 users per second and no errors were reported on any of the routes.

**LOCUST TESTING RESULTS:**
![tmp](https://user-images.githubusercontent.com/10621824/83352065-37a93e80-a349-11ea-9a4b-97c750bac450.png)

**CLOSES:**
closes #15 

**AUTHORS:**
@cldme 
